### PR TITLE
Feat: 마이페이지 내 유저 정보 수정 부분 추가

### DIFF
--- a/src/contexts/AuthProvider.jsx
+++ b/src/contexts/AuthProvider.jsx
@@ -50,7 +50,7 @@ export default function AuthProvider({ children }) {
   }, [isLogin, user.num]);
 
   return (
-    <AuthContext.Provider value={{ isLogin, user, setIsLogin }}>
+    <AuthContext.Provider value={{ isLogin, user, setIsLogin, setUser }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -23,6 +23,10 @@ const MyPage = () => {
 
   const handleUserInfoChange = () => {
     if (isEditing) {
+      if (editedNickname.replaceAll(' ', '') === '') {
+        alert('닉네임을 1자 이상 입력해주세요');
+        return;
+      }
       setUser({ ...user, nickname: editedNickname, intro: editedIntro });
     }
     setIsEditing(!isEditing);
@@ -30,20 +34,31 @@ const MyPage = () => {
 
   useEffect(() => {
     if (!user.num) return;
-    const changeUserInfo = async () => {
+
+    const updateAndFetchUserInfo = async () => {
       try {
-        const { error } = await supabase
+        const { error: updateError } = await supabase
           .from('users')
-          .update({ user_nickname: user.nickname, user_intro: user.intro })
+          .update({
+            user_nickname: user.nickname,
+            user_intro: user.intro,
+          })
           .eq('user_num', user.num);
-        if (error) throw error;
-      } catch (error) {
-        console.log(error);
+        if (updateError) throw updateError;
+
+        const { data, error: selectError } = await supabase
+          .from('users')
+          .select('*')
+          .eq('user_num', user.num);
+        if (selectError) throw selectError;
+
+        console.log(data);
+      } catch (err) {
+        console.log(err);
       }
     };
 
-    console.log('제대로 출력됨');
-    changeUserInfo();
+    updateAndFetchUserInfo();
   }, [user.num, user.nickname, user.intro]);
 
   return (

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -34,6 +34,7 @@ const MyPage = () => {
 
   useEffect(() => {
     if (!user.num) return;
+    if (!user.num || !user.nickname || !user.intro) return;
 
     const updateAndFetchUserInfo = async () => {
       try {
@@ -51,8 +52,6 @@ const MyPage = () => {
           .select('*')
           .eq('user_num', user.num);
         if (selectError) throw selectError;
-
-        console.log(data);
       } catch (err) {
         console.log(err);
       }

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -21,7 +21,6 @@ const MyPage = () => {
   const [editedIntro, setEditedIntro] = useState('');
   const [isEditing, setIsEditing] = useState(false);
   const [file, setFile] = useState(null);
-  const [uploading, setUploading] = useState(false);
 
   const handleFileChange = (e) => {
     setFile(e.target.files[0]);
@@ -30,26 +29,22 @@ const MyPage = () => {
   const uploadFileAndGetUrl = async () => {
     if (!file || !user.num) return null;
     const filePath = `test-bucket/${user.num}_${file.name}`;
-    setUploading(true);
 
     const { error: uploadError } = await supabase.storage
       .from('test-bucket')
       .upload(filePath, file);
     if (uploadError) {
       console.error('파일 업로드 에러:', uploadError);
-      setUploading(false);
       return null;
     }
 
-    const { data, error: urlError } = supabase.storage
+    const { data, error } = supabase.storage
       .from('test-bucket')
       .getPublicUrl(filePath);
-    if (urlError) {
-      console.error('public URL 가져오기 에러:', urlError);
-      setUploading(false);
+    if (error) {
+      console.error('public URL 가져오기 에러:', error);
       return null;
     }
-    setUploading(false);
     return data.publicUrl;
   };
 
@@ -59,7 +54,7 @@ const MyPage = () => {
         alert('닉네임을 1자 이상 입력해주세요');
         return;
       }
-      let updatedProfileImg = user.profile; // 기존 프로필 사진 유지
+      let updatedProfileImg = user.profile;
 
       if (file) {
         const url = await uploadFileAndGetUrl();
@@ -83,7 +78,7 @@ const MyPage = () => {
 
     const updateUserInfo = async () => {
       try {
-        const { error: updateError } = await supabase
+        const { error } = await supabase
           .from('users')
           .update({
             user_nickname: user.nickname,
@@ -91,9 +86,9 @@ const MyPage = () => {
             user_profile: user.profile,
           })
           .eq('user_num', user.num);
-        if (updateError) throw updateError;
-      } catch (err) {
-        console.log(err);
+        if (error) throw error;
+      } catch (error) {
+        console.log(error);
       }
     };
 

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -2,6 +2,9 @@ import styled from 'styled-components';
 import sampleImg from '../assets/다운로드.jpeg';
 import { useContext } from 'react';
 import { AuthContext } from '../contexts/AuthProvider';
+import { useState } from 'react';
+import { useEffect } from 'react';
+import { supabase } from '../supabase/client';
 
 const dummyArr = Array.from({ length: 4 }, (_, idx) => ({
   post_num: idx + 1,
@@ -13,7 +16,35 @@ const dummyArr = Array.from({ length: 4 }, (_, idx) => ({
 }));
 
 const MyPage = () => {
-  const { isLogin, user, setIsLogin } = useContext(AuthContext);
+  const { isLogin, user, setIsLogin, setUser } = useContext(AuthContext);
+  const [editedNickname, setEditedNickname] = useState('');
+  const [editedIntro, setEditedIntro] = useState('');
+  const [isEditing, setIsEditing] = useState(false);
+
+  const handleUserInfoChange = () => {
+    if (isEditing) {
+      setUser({ ...user, nickname: editedNickname, intro: editedIntro });
+    }
+    setIsEditing(!isEditing);
+  };
+
+  useEffect(() => {
+    if (!user.num) return;
+    const changeUserInfo = async () => {
+      try {
+        const { error } = await supabase
+          .from('users')
+          .update({ user_nickname: user.nickname, user_intro: user.intro })
+          .eq('user_num', user.num);
+        if (error) throw error;
+      } catch (error) {
+        console.log(error);
+      }
+    };
+
+    console.log('제대로 출력됨');
+    changeUserInfo();
+  }, [user.num, user.nickname, user.intro]);
 
   return (
     <div>
@@ -21,9 +52,30 @@ const MyPage = () => {
         <RoundButton></RoundButton>
         <StMyInfoWrapper>
           <StNickname>{user.nickname}</StNickname>
+          {isEditing ? (
+            <input
+              type="text"
+              value={editedNickname}
+              onChange={(e) => setEditedNickname(e.target.value)}
+            />
+          ) : (
+            ''
+          )}
           <StIntroduce>{user.intro}</StIntroduce>
+          {isEditing ? (
+            <textarea
+              name=""
+              id=""
+              value={editedIntro}
+              onChange={(e) => setEditedIntro(e.target.value)}
+            ></textarea>
+          ) : (
+            ''
+          )}
         </StMyInfoWrapper>
-        <StEditBtn>내 정보 수정하기</StEditBtn>
+        <StEditBtn value={isEditing} onClick={handleUserInfoChange}>
+          내 정보 수정하기
+        </StEditBtn>
       </StMyInfoChange>
       <StMyPostList>
         {dummyArr.map((post) => {


### PR DESCRIPTION
## ✨ feat: 마이페이지 내 유저 정보 수정 부분 추가

## 🔘 Part

- [x] FE

<br/>

## 🔎 작업 내용

- 마이페이지 내에서 유저 정보 수정하는 부분의 로직을 추가했습니다.

- 렌더링 시 깜빡거리는 현상으로 인해 프로필 이미지 크기와 배경 이미지 크기를 똑같이 맞췄습니다.

  <br/>

## 🖼️ 이미지 첨부(선택)

<img width="1470" alt="스크린샷 2025-02-15 01 19 08" src="https://github.com/user-attachments/assets/169be08a-5c66-4064-aea5-10dcd42a33a2" />

<br/>

## 💬 리뷰 요구사항(선택)

>  styled-components명과 input css는 신경쓰지 않고 했으니 그 부분은 제외하고 봐주시길 바랍니다.
> 추후 컴포넌트를 따로 분리할 예정입니다.
> 리팩터링을 나중에 한번에 하는게 나을까요 아니면 중간중간 하는게 나을까요~?
