### PR TITLE
feat : post페이지에서 입력한 사진 posts테이블로 업로드 성공

### DIFF
--- a/src/pages/Post.jsx
+++ b/src/pages/Post.jsx
@@ -3,49 +3,125 @@ import S from '../style/Post/Post.style';
 import { supabase } from '../supabase/client';
 import { useNavigate } from 'react-router-dom';
 
-const MOCK_DATA = ['일상', '운동', '취미', '맛집', '기타'];
+const postCategory = ['일상', '운동', '취미', '맛집', '기타'];
 const resetPost = {
   post_title: '',
   post_category: '',
   post_detail: '',
-  post_img_url: null,
 };
 
 const Post = () => {
   const [post, setPost] = useState(resetPost);
+  const [postImg, setPostImg] = useState(null);
   const navigate = useNavigate();
 
   const handleChange = (e) => {
     const { name, value } = e.target;
     setPost((prev) => ({
       ...prev,
-      [name]: value.trim(),
+      [name]: value,
     }));
   };
 
   const handleFileChange = (e) => {
-    const fileImage = URL.createObjectURL(e.target.files[0]);
-    setPost((prev) => ({ ...prev, post_img_url: fileImage }));
+    setPostImg(e.target.files[0]);
   };
 
+  // 유효성 검사
+  const validateSubmit = () => {
+    if (!post.post_title || !post.post_category || !post.post_detail) {
+      alert('모든 항목을 입력해 주세요.');
+      return false;
+    }
+
+    if (post.post_title.trim() === '' || post.post_detail.trim() === '') {
+      alert('내용을 입력해주세요.');
+      return false;
+    }
+  };
+
+  // 사진 없을 때 포스트
+  const withoutImgPost = async () => {
+    // post_num을 반환해줘야 하므로  trycatch 없이 에러처리
+    const {
+      data: [{ post_num }],
+      error,
+    } = await supabase.from('posts').insert(post).select();
+
+    if (error) {
+      alert('게시물 게시 실패');
+      console.error('게시물 게시 실패: ', error);
+      return { postSuccess: false };
+    }
+
+    return { postSuccess: true, post_num };
+  };
+
+  // 사진 storage로 업로드
+  const uploadImage = async () => {
+    const imageName = new Date().getTime() + postImg.lastModified;
+
+    try {
+      const { error } = await supabase.storage
+        .from('test-bucket')
+        .upload(`public/${imageName}`, postImg);
+
+      if (error) {
+        throw error;
+      }
+    } catch (error) {
+      alert('이미지 게시 실패');
+      console.error('이미지 게시 실패:', imgError);
+      return { uploadSuccess: false };
+    }
+
+    return { uploadSuccess: true, imageName };
+  };
+
+  // 사진과 함께 포스트
+  const withImgPost = async (post_num, imageName) => {
+    try {
+      const { error } = await supabase
+        .from('posts')
+        .update({
+          ...post,
+          post_img_url: `${import.meta.env.VITE_APP_SUPABASE_URL}/storage/v1/object/public/test-bucket/public/${imageName}`,
+        })
+        .eq('post_num', post_num);
+
+      if (error) {
+        throw error;
+      }
+    } catch (error) {
+      alert('이미지 업로드에 실패했습니다.');
+      console.error(error);
+      return { postImgSuccess: false };
+    }
+
+    return { postImgSuccess: true };
+  };
+
+  // 제출 관리
   const handleSubmit = async (e) => {
     e.preventDefault();
 
-    if (!post.post_title || !post.post_category || !post.post_detail) {
-      alert('모든 항목을 입력해 주세요.');
-      setPost(resetPost);
-      return;
-    }
+    if (!validateSubmit) return;
 
-    const { error } = await supabase.from('posts').insert(post);
-    if (error) {
-      alert('게시물 게시 실패');
-      console.log('게시물 게시 실패: ', error);
-      return;
-    }
+    const { postSuccess, post_num } = await withoutImgPost();
+    if (!postSuccess) return;
+
     alert('게시되었습니다.');
     setPost(resetPost);
+    setPostImg(null);
     navigate('/');
+
+    if (!postImg) return;
+
+    const { uploadSuccess, imageName } = await uploadImage();
+    if (!uploadSuccess) return;
+
+    const { postImgSuccess } = await withImgPost(post_num, imageName);
+    if (!postImgSuccess) return;
   };
 
   return (
@@ -59,7 +135,7 @@ const Post = () => {
             onChange={handleChange}
           >
             <option value="">카테고리를 선택하세요</option>
-            {MOCK_DATA.map((item) => (
+            {postCategory.map((item) => (
               <option value={item}>{item}</option>
             ))}
           </S.postSelect>
@@ -85,7 +161,9 @@ const Post = () => {
       </S.PostSection>
       <S.PostSection>
         <label htmlFor="input-file">첨부파일</label>
-        <S.FileLabel htmlFor="input-file">{post.post_img_url}</S.FileLabel>
+        <S.FileLabel htmlFor="input-file">
+          {!postImg ? null : postImg.name}
+        </S.FileLabel>
         <label htmlFor="input-file">업로드</label>
         <input
           type="file"


### PR DESCRIPTION
## ✨ feat : post페이지에서 입력한 사진 posts테이블로 업로드 성공

## 🔘 Part

- [x] FE

<br/>

## 🔎 작업 내용

- 제목과 내용에 띄어쓰기 안되는 부분 해결
- postImg 새로운 상태로 관리
- 사진 URL.createObjectURL로 처리한 부분 삭제
- 사진 supabase Buckets에 저장
- 사진 한글, 중복 안되는 부분 해결
- 사진 posts 테이블에 추가 성공
- MOCK_DATA postCategory로 변경
- handleSubmit에 의존이 높았던 부분 분리


  <br/>

## 🖼️ 이미지 첨부(선택)

<img src="https://github.com/user-attachments/assets/3f780a26-afbd-4154-a594-45a7255a5ee5" width="50%" height="50%"/>

<br/>

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  