### PR TITLE
Feat/login: 로그인 유효성 검사로직 수정 

### DIFF
--- a/src/constants/login.js
+++ b/src/constants/login.js
@@ -1,0 +1,4 @@
+export const LOGIN = {
+  MIN_PASSWORD_LENGTH: 8,
+  MAX_PASSWORD_LENGTH: 16,
+};

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -79,6 +79,8 @@ const Login = () => {
             setPassword(e.target.value);
           }}
           value={password}
+          minLegth={LOGIN.MIN_PASSWORD_LENGTH}
+          maxLength={LOGIN.MAX_PASSWORD_LENGTH}
         />
         <button type="submit">로그인</button>
       </form>

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -79,7 +79,7 @@ const Login = () => {
             setPassword(e.target.value);
           }}
           value={password}
-          minLegth={LOGIN.MIN_PASSWORD_LENGTH}
+          minLength={LOGIN.MIN_PASSWORD_LENGTH}
           maxLength={LOGIN.MAX_PASSWORD_LENGTH}
         />
         <button type="submit">로그인</button>

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -23,19 +23,6 @@ const Login = () => {
       return;
     }
 
-    // 패스워드 유효성 검사
-    if (password.length < LOGIN.MIN_PASSWORD_LENGTH) {
-      alert(
-        `비밀번호는 최소 ${LOGIN.MIN_PASSWORD_LENGTH}자 이상 입력해야 합니다.`,
-      );
-      return;
-    }
-    if (password.length > LOGIN.MAX_PASSWORD_LENGTH) {
-      alert(
-        `비밀번호는 최대 ${LOGIN.MAX_PASSWORD_LENGTH}자 미만 입력해야 합니다.`,
-      );
-      return;
-    }
     // 공백 포함 및 미입력 검사
     if (/\s/.test(password) || /\s/.test(inputEmail)) {
       alert('공백을 포함할 수 없습니다.');

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -2,7 +2,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { useState } from 'react';
 import { supabase } from '../supabase/client';
 import InputForAuth from '../components/InputForAuth';
-
+import { LOGIN } from '../constants/login';
 const Login = () => {
   const [inputEmail, setInputEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -19,19 +19,27 @@ const Login = () => {
     const trimmedInputEmail = inputEmail.trim();
     const trimmedPassword = password.trim();
 
+    // 이메일&비밀번호 미입력
     if (!trimmedInputEmail || !trimmedPassword) {
       alert('이메일과 비밀번호를 입력해 주세요.');
       return;
     }
-
+    // 이메일 유효성 검사
     if (!isValidEmail(trimmedInputEmail)) {
       alert('유효한 이메일을 입력해 주세요.');
       return;
     }
-
-    if (password.length < 8) {
-      alert('비밀번호는 최소 8자 이상 입력해야 합니다.');
+    // 패스워드 유효성 검사
+    if (password.length < LOGIN.MIN_PASSWORD_LENGTH) {
+      alert(
+        `비밀번호는 최소 ${LOGIN.MIN_PASSWORD_LENGTH}자 이상 입력해야 합니다.`,
+      );
       return;
+    }
+    if (password.length <= LOGIN.MAX_PASSWORD_LENGTH) {
+      alert(
+        `비밀번호는 최대 ${LOGIN.MAX_PASSWORD_LENGTH}자 미만 입력해야 합니다.`,
+      );
     }
 
     try {

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { supabase } from '../supabase/client';
 import InputForAuth from '../components/InputForAuth';
 import { LOGIN } from '../constants/login';
+
 const Login = () => {
   const [inputEmail, setInputEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -16,19 +17,12 @@ const Login = () => {
   const submitHandler = async (e) => {
     e.preventDefault();
 
-    const trimmedInputEmail = inputEmail.trim();
-    const trimmedPassword = password.trim();
-
-    // 이메일&비밀번호 미입력
-    if (!trimmedInputEmail || !trimmedPassword) {
-      alert('이메일과 비밀번호를 입력해 주세요.');
-      return;
-    }
     // 이메일 유효성 검사
-    if (!isValidEmail(trimmedInputEmail)) {
+    if (!isValidEmail(inputEmail)) {
       alert('유효한 이메일을 입력해 주세요.');
       return;
     }
+
     // 패스워드 유효성 검사
     if (password.length < LOGIN.MIN_PASSWORD_LENGTH) {
       alert(
@@ -36,16 +30,22 @@ const Login = () => {
       );
       return;
     }
-    if (password.length <= LOGIN.MAX_PASSWORD_LENGTH) {
+    if (password.length > LOGIN.MAX_PASSWORD_LENGTH) {
       alert(
         `비밀번호는 최대 ${LOGIN.MAX_PASSWORD_LENGTH}자 미만 입력해야 합니다.`,
       );
+      return;
+    }
+    // 공백 포함 및 미입력 검사
+    if (/\s/.test(password) || /\s/.test(inputEmail)) {
+      alert('공백을 포함할 수 없습니다.');
+      return;
     }
 
     try {
       const result = await supabase.auth.signInWithPassword({
-        email: trimmedInputEmail,
-        password: trimmedPassword,
+        email: inputEmail,
+        password: password,
       });
       if (result.error) {
         alert(`로그인 실패: ${result.error.message}`);

--- a/src/pages/SignUp.jsx
+++ b/src/pages/SignUp.jsx
@@ -77,9 +77,18 @@ const SignUp = () => {
             name="닉네임"
             id="nickname"
             {...inputNickname}
+            minLength="1"
+            maxLength="16"
           />
           <SignUpInput type="email" name="이메일" id="email" {...inputEmail} />
-          <SignUpInput type="password" name="비밀번호" id="pwd" {...inputPwd} />
+          <SignUpInput
+            type="password"
+            name="비밀번호"
+            id="pwd"
+            {...inputPwd}
+            minLength={LOGIN.MIN_PASSWORD_LENGTH}
+            maxLength={LOGIN.MAX_PASSWORD_LENGTH}
+          />
           <SignUpInput
             type="password"
             name="비밀번호확인"

--- a/src/pages/SignUp.jsx
+++ b/src/pages/SignUp.jsx
@@ -18,22 +18,39 @@ const SignUp = () => {
     const email = inputEmail.value;
     const password = inputPwd.value;
     const confirmPwd = inputConfirmPwd.value;
+
+    const isValidUsername = (username) => {
+      const usernameRegex = /^[a-zA-Z0-9가-힣_]{1,16}$/;
+      return usernameRegex.test(username);
+    };
+
+    // 패스워드 유효성 검사
     if (password !== confirmPwd) {
       alert('비밀번호를 다시 확인해주세요!');
       return;
     }
 
-    // 패스워드 유효성 검사
     if (password.length < LOGIN.MIN_PASSWORD_LENGTH) {
       alert(
         `비밀번호는 최소 ${LOGIN.MIN_PASSWORD_LENGTH}자 이상 입력해야 합니다.`,
       );
       return;
     }
-    if (password.length <= LOGIN.MAX_PASSWORD_LENGTH) {
+    if (password.length > LOGIN.MAX_PASSWORD_LENGTH) {
       alert(
         `비밀번호는 최대 ${LOGIN.MAX_PASSWORD_LENGTH}자 이하 입력해야 합니다.`,
       );
+      return;
+    }
+    if (/\s/.test(password) || /\s/.test(email)) {
+      alert('공백을 포함할 수 없습니다.');
+      return;
+    }
+
+    //  닉네임 유효성 검사
+    if (!isValidUsername(inputNickname)) {
+      alert('닉네임은 1~16자의 한글, 영어, 숫자, 언더스코어(_)만 허용됩니다.');
+      return;
     }
 
     try {

--- a/src/pages/SignUp.jsx
+++ b/src/pages/SignUp.jsx
@@ -96,6 +96,8 @@ const SignUp = () => {
             type="password"
             name="비밀번호확인"
             id="confirmPwd"
+            minLength={LOGIN.MIN_PASSWORD_LENGTH}
+            maxLength={LOGIN.MAX_PASSWORD_LENGTH}
             {...inputConfirmPwd}
           />
           <StSubmitBtn type="submit">확인</StSubmitBtn>

--- a/src/pages/SignUp.jsx
+++ b/src/pages/SignUp.jsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import SignUpInput from '../components/SignUp/SignUpInput';
 import useInput from '../hooks/useInput';
-
+import { LOGIN } from '../constants/login';
 const SignUp = () => {
   const inputEmail = useInput('');
   const inputNickname = useInput('');
@@ -22,6 +22,20 @@ const SignUp = () => {
       alert('비밀번호를 다시 확인해주세요!');
       return;
     }
+
+    // 패스워드 유효성 검사
+    if (password.length < LOGIN.MIN_PASSWORD_LENGTH) {
+      alert(
+        `비밀번호는 최소 ${LOGIN.MIN_PASSWORD_LENGTH}자 이상 입력해야 합니다.`,
+      );
+      return;
+    }
+    if (password.length <= LOGIN.MAX_PASSWORD_LENGTH) {
+      alert(
+        `비밀번호는 최대 ${LOGIN.MAX_PASSWORD_LENGTH}자 이하 입력해야 합니다.`,
+      );
+    }
+
     try {
       // Supabase auth를 통해 회원가입
       const { data: authData, error: authError } = await supabase.auth.signUp({

--- a/src/pages/SignUp.jsx
+++ b/src/pages/SignUp.jsx
@@ -48,7 +48,7 @@ const SignUp = () => {
     }
 
     //  닉네임 유효성 검사
-    if (!isValidUsername(inputNickname)) {
+    if (!isValidUsername(inputNickname.value)) {
       alert('닉네임은 1~16자의 한글, 영어, 숫자, 언더스코어(_)만 허용됩니다.');
       return;
     }

--- a/src/pages/SignUp.jsx
+++ b/src/pages/SignUp.jsx
@@ -30,18 +30,6 @@ const SignUp = () => {
       return;
     }
 
-    if (password.length < LOGIN.MIN_PASSWORD_LENGTH) {
-      alert(
-        `비밀번호는 최소 ${LOGIN.MIN_PASSWORD_LENGTH}자 이상 입력해야 합니다.`,
-      );
-      return;
-    }
-    if (password.length > LOGIN.MAX_PASSWORD_LENGTH) {
-      alert(
-        `비밀번호는 최대 ${LOGIN.MAX_PASSWORD_LENGTH}자 이하 입력해야 합니다.`,
-      );
-      return;
-    }
     if (/\s/.test(password) || /\s/.test(email)) {
       alert('공백을 포함할 수 없습니다.');
       return;

--- a/src/style/Auth/Auth.Input.style.jsx
+++ b/src/style/Auth/Auth.Input.style.jsx
@@ -9,6 +9,8 @@ S.AuthInput = styled.input.attrs((props) => ({
   value: props.value,
   onChange: props.onChange,
   id: props.id,
+  minLength: props.minLength,
+  maxLength: props.maxLength,
 }))`
   border: 1px solid #f3c301;
   border-radius: 30px;


### PR DESCRIPTION
## ✨ Feat/login: 로그인 유효성 검사로직 수정 


## 🔘 Part

- [x] FE

<br/>

## 🔎 작업 내용

기존 :
1. 로그인 시 앞뒤공백을 입력해도 자동으로 잘라서 검사로직 수행 ->  공백자체가 있는지 없는지 검사후 재 로그인 안내
2. 회원가입시 공백이 포함된 비밀번호 사용가능 ->  공백을 포함할 수 없도록 수정
3. 회원가입, 로그인시 최대 입력가능한 비밀번호가 존재 하지 않음❌
4. 회원가입 시 닉네임 길이제한이 없고, 특수문자 다사용가능 -> 공백특수문자를 포함한 닉네임 생성가능 및 길이제한이 없었던 문제 수정
5. 로그인시 비밀번호 무한입력 가능, 비밀번호 검사 로직으로 수행 -> 입력자체 조건을 minLength, maxLength 자체로 막음 

  <br/>


